### PR TITLE
chore(vite): add @rollup/plugin-replace to replace SDK version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1-beta.3",
       "license": "MIT",
       "devDependencies": {
+        "@rollup/plugin-replace": "^5.0.2",
         "@vitest/coverage-c8": "^0.29.7",
         "typescript": "^4.9.3",
         "vite": "^4.2.0",
@@ -410,6 +411,49 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
+      "integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@types/chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
@@ -424,6 +468,12 @@
       "dependencies": {
         "@types/chai": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -834,6 +884,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1078,6 +1134,18 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -1254,6 +1322,18 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "coverage": "vitest run --coverage"
   },
   "devDependencies": {
+    "@rollup/plugin-replace": "^5.0.2",
     "@vitest/coverage-c8": "^0.29.7",
     "typescript": "^4.9.3",
     "vite": "^4.2.0",

--- a/src/util/visionFetch.ts
+++ b/src/util/visionFetch.ts
@@ -15,7 +15,7 @@ export const visionFetch = async (
       ...overrides?.headers,
       Authorization: config.getBasicAuth(),
       "x-api-key": config.apiKey,
-      "GLAIR-Vision-Nodejs-SDK-Version": "0.0.1-beta.3",
+      "GLAIR-Vision-Nodejs-SDK-Version": "__packageVersion",
     },
     method: overrides?.method || "GET",
   };
@@ -25,5 +25,6 @@ export const visionFetch = async (
   if (resp.ok) {
     return respObj;
   }
+
   throw respObj;
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,9 @@
 import { defineConfig } from "vite";
 
+import replace from "@rollup/plugin-replace";
+
+import packageDef from "./package.json";
+
 // https://vitejs.dev/config/
 export default defineConfig({
   build: {
@@ -20,6 +24,12 @@ export default defineConfig({
       // Webpack supports "data:" and "file:" URIs by default.
       // You may need an additional plugin to handle "node:" URIs.
       external: ["node:fs", "node:path", "fs"],
+      plugins: [
+        replace({
+          preventAssignment: true,
+          __packageVersion: `${packageDef.version}`,
+        }),
+      ],
     },
     minify: false,
   },


### PR DESCRIPTION
## Overview

This pull request adds compile-time API versioning to the `visionFetch` function that automatically update when the package version changes so it requires less maintenance.